### PR TITLE
update success checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# pyCharm settings
+.idea/*
+
 # mkdocs documentation
 /site
 

--- a/fiddy/derivative_check.py
+++ b/fiddy/derivative_check.py
@@ -117,7 +117,6 @@ class NumpyIsCloseDerivativeCheck(DerivativeCheck):
 
     def method(self, *args, **kwargs):
         directional_derivative_check_results = []
-        success = True
         for direction_index, directional_derivative in enumerate(
             self.derivative.directional_derivatives
         ):

--- a/fiddy/success.py
+++ b/fiddy/success.py
@@ -93,28 +93,27 @@ class Consistency(Success):
             values = list(results.values())
             success_by_size[size] = np.isclose(
                 values,
-                values[0],
-                rtol=self.rtol,
-                atol=self.atol,
+                np.nanmean(values),
+                rtol=self.rtol/2,
+                atol=self.atol/2,
                 equal_nan=self.equal_nan,
             ).all()
 
         consistent_results = [
-            value
+            np.nanmean([v for v in results_by_size[size].values()])
             for size, success in success_by_size.items()
-            for value in results_by_size[size].values()
             if success
         ]
 
         success = False
+        value = np.nanmean(np.array(consistent_results), axis=0)
         if consistent_results:
             success = np.isclose(
                 consistent_results,
-                consistent_results[0],
+                value,
                 rtol=self.rtol,
                 atol=self.atol,
-                equal_nan=self.equal_nan,
-            ).all()
-        value = np.average(np.array(consistent_results), axis=0)
+                equal_nan=self.equal_nan
+            ).all() and not np.isnan(consistent_results).all()
 
         return success, value

--- a/fiddy/success.py
+++ b/fiddy/success.py
@@ -93,14 +93,14 @@ class Consistency(Success):
             values = list(results.values())
             success_by_size[size] = np.isclose(
                 values,
-                np.nanmean(values),
+                np.nanmean(values, axis=0),
                 rtol=self.rtol/2,
                 atol=self.atol/2,
                 equal_nan=self.equal_nan,
             ).all()
 
         consistent_results = [
-            np.nanmean([v for v in results_by_size[size].values()])
+            np.nanmean(list(results_by_size[size].values()), axis=0)
             for size, success in success_by_size.items()
             if success
         ]
@@ -115,5 +115,6 @@ class Consistency(Success):
                 atol=self.atol,
                 equal_nan=self.equal_nan
             ).all() and not np.isnan(consistent_results).all()
+        value = np.average(np.array(consistent_results), axis=0)
 
         return success, value

--- a/tests/extensions/amici/test_amici.py
+++ b/tests/extensions/amici/test_amici.py
@@ -174,8 +174,6 @@ def test_simulate_petab_to_functions(problem_generator, scaled_parameters):
         ].parameterScale
     )
 
-    analysis_classes = []
-
     derivative = get_derivative(
         function=amici_function,
         point=point,
@@ -184,7 +182,6 @@ def test_simulate_petab_to_functions(problem_generator, scaled_parameters):
         method_ids=[MethodId.FORWARD, MethodId.BACKWARD, MethodId.CENTRAL],
         success_checker=Consistency(),
     )
-    test_value = derivative.value
 
     check = NumpyIsCloseDerivativeCheck(
         derivative=derivative,


### PR DESCRIPTION
changes success checks heuristics a bit. notably using mean rather than first entry for consistency checks, using lower tolerances for by size checks and averaging after by size checks.

Without these changes, I rand into an abysmal number of false rejections for gradient checks with AMICI for the benchmark collection.