### PR TITLE
Numpy 2.0 compatibility

### DIFF
--- a/tests/test_derivative.py
+++ b/tests/test_derivative.py
@@ -16,14 +16,14 @@ ATOL = 1e-15
 
 
 def rosenbrock(input_value, output_shape):
-    size = np.product(output_shape)
+    size = np.prod(output_shape)
     values = [rosen(input_value + i * 0.01) for i in range(size)]
     output = np.array(values).reshape(output_shape)
     return output
 
 
 def rosenbrock_der(input_value, output_shape):
-    size = np.product(output_shape)
+    size = np.prod(output_shape)
     input_shape = input_value.shape
     values = [rosen_der(input_value + i * 0.01) for i in range(size)]
     # The input shape is the "deepest" dimension(s), i.e. expect


### PR DESCRIPTION
Fixes `AttributeError: module 'numpy' has no attribute 'product'`