### PR TITLE
Fix pyproject.toml optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "fiddy"
 description = "Finite difference methods"
 readme = "README.md"
-dynamic = ["version"]
+dynamic = ["version", "optional-dependencies"]
 license = { file = "LICENSE" }
 authors = [
     { name = "The fiddy developers", email = "dilan.pathirana@uni-bonn.de" }


### PR DESCRIPTION
Declare `optional-dependencies` as dynamic to use the settings from `setup.cfg`.

Closes #58