### PR TITLE
Silence mean-of-empty-slice warnings

### DIFF
--- a/fiddy/directional_derivative.py
+++ b/fiddy/directional_derivative.py
@@ -143,7 +143,7 @@ class DirectionalDerivative:
     expected_result: ExpectedDirectionalDerivative = None
     # If True, no further computations will occur in this class.
     success: bool = False
-    value: Type.SCALAR = None
+    value: Type.SCALAR = np.nan
     completed: bool = False
     # Whether to complete as soon as the success method returns `True`.
     fast: bool = False

--- a/fiddy/success.py
+++ b/fiddy/success.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -68,7 +69,7 @@ class Consistency(Success):
 
     def method(
         self, directional_derivative: DirectionalDerivative
-    ) -> [bool, float]:
+    ) -> tuple[bool, float]:
         # FIXME string literals
         computer_results = directional_derivative.get_computer_results()
         analysis_results = directional_derivative.get_analysis_results()
@@ -89,26 +90,36 @@ class Consistency(Success):
         success_by_size = {}
         for size, results in results_by_size.items():
             values = list(results.values())
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", "Mean of empty slice", RuntimeWarning
+                )
+                mean = np.nanmean(values, axis=0)
             success_by_size[size] = np.isclose(
                 values,
-                np.nanmean(values, axis=0),
+                mean,
                 rtol=self.rtol / 2,
                 atol=self.atol / 2,
                 equal_nan=self.equal_nan,
             ).all()
 
-        consistent_results = np.array(
-            [
-                np.nanmean(list(results_by_size[size].values()), axis=0)
-                for size, success in success_by_size.items()
-                if success
-            ]
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", "Mean of empty slice", RuntimeWarning
+            )
 
-        if len(consistent_results) == 0:
-            return False, np.nan
+            consistent_results = np.array(
+                [
+                    np.nanmean(list(results_by_size[size].values()), axis=0)
+                    for size, success in success_by_size.items()
+                    if success
+                ]
+            )
 
-        value = np.nanmean(consistent_results, axis=0)
+            if len(consistent_results) == 0:
+                return False, np.nan
+
+            value = np.nanmean(consistent_results, axis=0)
         success = (
             np.isclose(
                 consistent_results,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,12 @@ lint.ignore = [
 ]
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    # https://github.com/sbmlteam/python-libsbml/issues/40
+    "ignore:builtin type .* has no __module__ attribute:DeprecationWarning",
+    # amici
+    "ignore:Conservation laws for non-constant species .*:UserWarning",
+]


### PR DESCRIPTION
Silence mean-of-empty-slice warnings, fail on warnings, and fix DirectionalDerivative.value type (supposed to be float, but was None).
